### PR TITLE
fix: alert style in dark mode

### DIFF
--- a/src/options/Options.vue
+++ b/src/options/Options.vue
@@ -243,4 +243,10 @@ a[target='_blank']::after {
     border-bottom: 1px solid #ccc;
     text-align: center;
 }
+
+@media (prefers-color-scheme: dark) {
+    .alert {
+        background: rgba(120, 120, 120, 0.2);
+    }
+}
 </style>


### PR DESCRIPTION
the alert style is not correct in dark mode.

## before
![image](https://user-images.githubusercontent.com/38490578/179356390-35cdae9d-be7b-4afa-a4d7-7c2ce9a9ef8b.png)

## after fix
<img width="1498" alt="image" src="https://user-images.githubusercontent.com/38490578/179356560-9db53a11-93c3-4ff8-9e05-96a2d7a7ab87.png">

